### PR TITLE
keep tag check

### DIFF
--- a/src/is-object.js
+++ b/src/is-object.js
@@ -78,6 +78,8 @@ const isWeakSet = o => {
   return true
 }
 
+const isTagged = o => Object.prototype.toString.call(o) !== '[object Object]'
+
 module.exports = x =>
   !isArguments(x) &&
   !isBigint(x) &&
@@ -91,4 +93,5 @@ module.exports = x =>
   !isSymbol(x) &&
   !isTypedArray(x) &&
   !isWeakMap(x) &&
-  !isWeakSet(x)
+  !isWeakSet(x) &&
+  !isTagged(x)

--- a/src/is-object.spec.js
+++ b/src/is-object.spec.js
@@ -44,7 +44,9 @@ describe('is-object', () => {
       () => new Set([1]),
       () => new Map([[1, 2]]),
       () => new WeakSet([{ a: 1 }]),
-      () => new WeakMap([[{ a: 1 }, 2]])
+      () => new WeakMap([[{ a: 1 }, 2]]),
+
+      () => new Error()
     ]
 
     candidateGetters.forEach((candidateGetter, i) => {

--- a/src/stringify.spec.js
+++ b/src/stringify.spec.js
@@ -171,12 +171,12 @@ describe('stringify', () => {
 
     it('fails on "imitation" POJSO array', () => {
       expect(() => stringify(Object.setPrototypeOf([], Object.prototype)))
-        .toThrowError('Can\'t stringify a value with non-configurable property "length"')
+        .toThrowError('Can\'t stringify a non-Plain Old JavaScript Object with prototype Object.prototype')
     })
 
     it('fails on "imitation" POJSO error', () => {
       expect(() => stringify(Object.setPrototypeOf(Error(), Object.prototype)))
-        .toThrowError('Can\'t stringify a value with non-enumerable property "stack"')
+        .toThrowError('Can\'t stringify a non-Plain Old JavaScript Object with prototype Object.prototype')
     })
   })
 


### PR DESCRIPTION
a1348f015c5f0b15a1483df3ec32d17793b6fb99 removed the `Object.prototype.toString.call(x) === '[object Object]'` check in favor of the various `is` modules. But the check is still useful, especially on the web platform - for example,

```js
let o = Object.setPrototypeOf(new Image, Object.prototype);
```

produces an object with no properties and which inherits directly from `Object.prototype`, but which is still identifiably unusual:

```js
Object.prototype.toString.call(o) // "[object Image]"
Object.getOwnPropertyDescriptor(Image.prototype, 'src').get.call(o) // does not throw
```

(Though at least for the second you could argue this is equivalent to the `Image` constructor putting the objects it constructs into a `WeakMap`, which presumably should not prevent them from being serialized.)

There are many, many similarly tagged objects - `navigator.plugins`, `NodeLists` as returned from `document.querySelectorAll`, etc. So for completeness it's probably best to keep this check in.